### PR TITLE
Add CircleCI runner container example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,18 @@ jobs:
       - run:
           name: Run tests
           command: go test ./...
+  vm-test:
+    machine:
+      enabled: true
+    resource_class: grub-test-runner
+    steps:
+      - checkout
+      - run: docker compose up --abort-on-container-exit
+      - run: docker compose down
 workflows:
   test:
     jobs:
       - test
+      - vm-test:
+          requires:
+            - test

--- a/.github/workflows/vm-test.yml
+++ b/.github/workflows/vm-test.yml
@@ -1,0 +1,17 @@
+name: Bootrecov VM Test
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  boot-test:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run QEMU boot test
+        run: |
+          docker compose up --abort-on-container-exit
+          docker compose down
+

--- a/README.md
+++ b/README.md
@@ -61,3 +61,25 @@ All files for this test live under the `docker/` directory.
 
 A CircleCI workflow runs `go test ./...` to verify the project builds and tests pass.
 
+A GitHub Actions workflow in `.github/workflows/vm-test.yml` can run the QEMU
+boot test automatically. It requires a self-hosted runner with Docker and KVM
+so the `docker compose` service can launch the VM.
+
+### CircleCI self-hosted runner
+
+The `circleci-runner/` directory contains a `Dockerfile` and sample
+`launch-agent-config.yaml` for running a CircleCI runner with KVM support.
+Build and start the runner container with:
+
+```bash
+docker build -t circleci-kvm-runner circleci-runner
+docker run --rm -it --privileged \
+  -v /dev/kvm:/dev/kvm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  circleci-kvm-runner
+```
+
+Replace `YOUR_RUNNER_TOKEN` in `launch-agent-config.yaml` with the token from
+the CircleCI UI. The `vm-test` job in `.circleci/config.yml` will execute the
+Compose-based boot test on this runner.
+

--- a/circleci-runner/Dockerfile
+++ b/circleci-runner/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y curl sudo qemu-system-x86 kmod && \
+    useradd -m circleci && \
+    echo "circleci ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER circleci
+WORKDIR /home/circleci
+
+# Install CircleCI runner
+RUN curl -fsSL https://circle.ci/runner-install.sh | bash
+
+COPY launch-agent-config.yaml .
+
+CMD ["/home/circleci/circleci-launch-agent"]

--- a/circleci-runner/launch-agent-config.yaml
+++ b/circleci-runner/launch-agent-config.yaml
@@ -1,0 +1,5 @@
+api:
+  auth_token: YOUR_RUNNER_TOKEN
+runner:
+  name: grub-test-runner
+  working_directory: /home/circleci/runner


### PR DESCRIPTION
## Summary
- add sample Dockerfile to run CircleCI runner with KVM
- show how to launch the runner from the README
- extend CircleCI config with a vm-test job using the runner

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68788bc68a188324b98287855e5daef6