### PR TITLE
Fix docker image missing mkfs.fat

### DIFF
--- a/docker/run_vm.sh
+++ b/docker/run_vm.sh
@@ -22,7 +22,7 @@ fi
 # install packages needed to build and run an Arch VM
 # qemu now requires choosing a provider. "qemu-desktop" includes the SDL UI used
 # in this script and replaces the old "qemu"/"qemu-arch-extra" packages.
-pacman -Sy --noconfirm qemu-desktop arch-install-scripts grub efibootmgr edk2-ovmf go git parted
+pacman -Sy --noconfirm qemu-desktop arch-install-scripts grub efibootmgr edk2-ovmf go git parted dosfstools
 
 # build bootrecov binary
 cd /workspace/bootrecov


### PR DESCRIPTION
## Summary
- install `dosfstools` in docker test script so `mkfs.fat` is available

## Testing
- `go test ./...`
- ❌ `docker compose up` *(fails: `command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_687a9cd4bf3883248b5b4ebb4e9311b2