### PR TITLE
Fix loop partition creation

### DIFF
--- a/docker/run_vm.sh
+++ b/docker/run_vm.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# ensure the loop driver supports partitions. some container hosts load it with
+# `max_part=0`, which prevents creation of loopXpY nodes. attempt to reload the
+# module with a reasonable partition count if possible.
+if [[ -f /sys/module/loop/parameters/max_part && "$(cat /sys/module/loop/parameters/max_part)" -eq 0 ]]; then
+  if command -v modprobe >/dev/null 2>&1; then
+    modprobe -r loop >/dev/null 2>&1 || true
+    modprobe loop max_part=8 >/dev/null 2>&1 || true
+  fi
+fi
+
 # ensure loop device nodes exist. some container runtimes don't provide them
 if [[ ! -e /dev/loop-control ]]; then
   modprobe loop 2>/dev/null || true
@@ -8,7 +18,7 @@ fi
 if [[ ! -e /dev/loop-control ]]; then
   mknod /dev/loop-control c 10 237
 fi
-for i in $(seq 0 7); do
+for i in $(seq 0 31); do
   [[ -e /dev/loop${i} ]] || mknod /dev/loop${i} b 7 ${i}
 done
 
@@ -35,14 +45,14 @@ MNT=/mnt/archvm
 
 mkdir -p /vm
 
-# create 2G disk image quickly
-truncate -s 2G "$IMG"
+# create larger disk image so pacstrap doesn't run out of space
+truncate -s 8G "$IMG"
 
 # partition disk for UEFI
 parted -s "$IMG" mklabel gpt
-parted -s "$IMG" mkpart ESP fat32 1MiB 256MiB
+parted -s "$IMG" mkpart ESP fat32 1MiB 512MiB
 parted -s "$IMG" set 1 esp on
-parted -s "$IMG" mkpart primary ext4 256MiB 100%
+parted -s "$IMG" mkpart primary ext4 512MiB 100%
 
 # helper to wait for partition device nodes
 wait_for_partitions() {
@@ -85,17 +95,37 @@ install -Dm755 ./bootrecov "$MNT/usr/local/bin/bootrecov"
 arch-chroot "$MNT" grub-install --target=x86_64-efi --efi-directory=/boot --bootloader-id=GRUB
 arch-chroot "$MNT" grub-mkconfig -o /boot/grub/grub.cfg
 
-# run bootrecov once to generate backup and grub entry
-arch-chroot "$MNT" bootrecov || true
+
+# bootrecov requires a TTY for its interactive UI which isn't available during
+# automated image creation. Skip running it here; users can invoke it manually
+# once the VM boots.
 
 umount "$MNT/boot"
 umount "$MNT"
 losetup -d "$device"
 
 # start the VM. Use ctrl-a x to exit QEMU if using -nographic
+# locate an OVMF firmware image. different distros install it to different
+# paths, so check a few common locations.
+OVMF_BIOS=""
+for p in \
+  /usr/share/edk2-ovmf/x64/OVMF_CODE.fd \
+  /usr/share/OVMF/OVMF_CODE.fd \
+  /usr/share/OVMF/OVMF_CODE_4M.fd \
+  /usr/share/qemu/OVMF_CODE.fd; do
+  if [[ -f "$p" ]]; then
+    OVMF_BIOS="$p"
+    break
+  fi
+done
+if [[ -z "$OVMF_BIOS" ]]; then
+  echo "OVMF firmware not found" >&2
+  exit 1
+fi
+
 qemu-system-x86_64 \
   -m 1024 \
   -drive file="$IMG",format=raw,if=virtio \
-  -bios /usr/share/edk2-ovmf/x64/OVMF_CODE.fd \
+  -bios "$OVMF_BIOS" \
   -display sdl
 


### PR DESCRIPTION
## Summary
- reload loop module with partitions enabled if needed
- fall back to loop partitions again instead of manual offsets
- ensure disk image is large enough and boot partition is 512MiB
- search several paths for OVMF firmware and skip running bootrecov in the chroot

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687aa4d3132c8324b480d0178dfdb1fd